### PR TITLE
cleanup idle clients

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  branch = "master"
+  digest = "1:f9cc35fce7f75ce0aa65aac69464ff05e429dd9f98193b3422711c8060d2e873"
+  name = "github.com/alexlukichev/thrift-hbase"
+  packages = ["gen-go/hbase"]
+  pruneopts = "UT"
+  revision = "7d0d6d7b7a51786667e0afe0fc8798cbf8353f5b"
+
+[[projects]]
   digest = "1:2505ada8a497ded339532cfaae30c15365f4e82245a3dbaff7a8453c086b0667"
   name = "github.com/apache/thrift"
   packages = ["lib/go/thrift"]
@@ -48,6 +56,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/alexlukichev/thrift-hbase/gen-go/hbase",
     "github.com/apache/thrift/lib/go/thrift",
     "gotest.tools/assert",
   ]

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
+	"time"
 
 	"gotest.tools/assert"
 )
@@ -23,12 +24,40 @@ func TestPutAndScan(t *testing.T) {
 	client := NewClient(hostPort, 10, 1, 1)
 	defer client.Close(context.Background())
 
+	dataStr, err := createAndFillTable(t, client)
+	if err != nil {
+		t.Errorf("can't create and fill table: %s", err.Error())
+		return
+	}
+
+	result, err := scanTable(t, client, "test", "!", "~", []string{"cf:c0", "cf:c1"})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	dataStrJson, err := json.Marshal(dataStr)
+	if err != nil {
+		t.Errorf("Cannot marshal: %v", dataStr)
+		return
+	}
+
+	resultStrJson, err := json.Marshal(result)
+	if err != nil {
+		t.Errorf("Cannot marshal: %v", result)
+		return
+	}
+
+	assert.Assert(t, string(dataStrJson) == string(resultStrJson), "Result doesn't match: %v != %v", string(dataStrJson), string(resultStrJson))
+}
+
+func createAndFillTable(t *testing.T, client *Client) (map[string]map[string]string, error) {
 	err := client.CreateTable(context.Background(), []byte("test"), [][]byte{
 		[]byte("cf"),
 	})
 	if err != nil && err != AlreadyExists {
 		t.Errorf("Cannot create table: %s", err.Error())
-		return
+		return nil, err
 	}
 
 	dataStr := map[string]map[string]string{
@@ -51,32 +80,38 @@ func TestPutAndScan(t *testing.T) {
 		dataBinary[rkey] = rbinary
 	}
 
-	ctx := context.Background()
-	err = client.Put(ctx, []byte("test"), []Row{
+	err = client.Put(context.Background(), []byte("test"), []Row{
 		Row{[]byte("r0"), map[string][]byte{"cf:c0": []byte("123"), "cf:c1": []byte("456")}},
 		Row{[]byte("r1"), map[string][]byte{"cf:c0": []byte("789"), "cf:c1": []byte("123")}},
 	})
 	if err != nil {
 		t.Errorf("Cannot put data in the DB: %s", err.Error())
-		return
+		return nil, err
 	}
+	return dataStr, err
+}
 
-	scanner, err := client.Scan(ctx, []byte("test"), []byte("!"), []byte("~"), [][]byte{[]byte("cf:c0"), []byte("cf:c1")})
+func scanTable(t *testing.T, client *Client, table string, start string, end string, columns []string) (map[string]map[string]string, error) {
+	byte_columns := make([][]byte, 0)
+	for _, col := range columns {
+		byte_columns = append(byte_columns, []byte(col))
+	}
+	scanner, err := client.Scan(context.Background(), []byte(table), []byte(start), []byte(end), byte_columns)
 	if err != nil {
 		t.Errorf("Cannot create scanner: %s", err.Error())
-		return
+		return nil, err
 	}
 	defer scanner.Close()
 
 	result := make(map[string]map[string]string)
 	for {
-		row, cols, err := scanner.Next(ctx)
+		row, cols, err := scanner.Next(context.Background())
 		if err == EOF {
 			break
 		}
 		if err != nil {
 			t.Errorf("Cannot iterate scanner: %s", err.Error())
-			return
+			return nil, err
 		}
 		rowMap := make(map[string]string)
 		for colNameBytes, colValueBytes := range cols {
@@ -85,16 +120,33 @@ func TestPutAndScan(t *testing.T) {
 		result[string(row)] = rowMap
 	}
 
-	dataStrJson, err := json.Marshal(dataStr)
-	if err != nil {
-		t.Errorf("Cannot marshal: %v", dataStr)
-		return
-	}
-	resultStrJson, err := json.Marshal(result)
-	if err != nil {
-		t.Errorf("Cannot marshal: %v", result)
-		return
-	}
+	return result, err
+}
 
-	assert.Assert(t, string(dataStrJson) == string(resultStrJson), "Result doesn't match: %v != %v", string(dataStrJson), string(resultStrJson))
+func TestScanAfterIdle(t *testing.T) {
+	client := NewClient(hostPort, 10, 1, 1)
+	defer client.Close(context.Background())
+
+	_, err := createAndFillTable(t, client)
+	if err != nil {
+		t.Errorf("can't create and fill table: %s", err.Error())
+		return
+	}
+	t.Log("Created and fill table")
+
+	_, err = scanTable(t, client, "test", "!", "~", []string{"cf:c0", "cf:c1"})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	t.Log("Completed first scan")
+
+	time.Sleep(2 * time.Minute)
+
+	t.Log("Started seconds scan")
+	_, err = scanTable(t, client, "test", "!", "~", []string{"cf:c0", "cf:c1"})
+	if err != nil {
+		t.Error(err)
+		return
+	}
 }

--- a/pool.go
+++ b/pool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	hb "github.com/alexlukichev/thrift-hbase/gen-go/hbase"
 	"github.com/apache/thrift/lib/go/thrift"
@@ -23,10 +24,11 @@ func (c HBaseClient) HBase() hb.Hbase {
 type Pool struct {
 	hostPort string
 
-	clients       chan *HBaseClient
-	poolSize      int
-	activeClients int
-	clientLock    sync.Locker
+	clients   chan *HBaseClient
+	createSem chan bool
+
+	poolSize   int
+	clientLock sync.Locker
 
 	protocolFactory  thrift.TProtocolFactory
 	transportFactory thrift.TTransportFactory
@@ -38,8 +40,8 @@ func NewPool(hostPort string, poolSize int) *Pool {
 	return &Pool{
 		hostPort:         hostPort,
 		clients:          make(chan *HBaseClient, poolSize),
+		createSem:        make(chan bool, poolSize),
 		poolSize:         poolSize,
-		activeClients:    0,
 		clientLock:       &sync.Mutex{},
 		protocolFactory:  thrift.NewTBinaryProtocolFactoryDefault(), // "binary" protocol
 		transportFactory: thrift.NewTBufferedTransportFactory(8192), // "buffered" transport
@@ -48,77 +50,65 @@ func NewPool(hostPort string, poolSize int) *Pool {
 }
 
 func (p *Pool) Acquire(ctx context.Context) (*HBaseClient, error) {
-	if p.closing {
-		return nil, PoolClosed
-	}
-
-	if p.activeClients < p.poolSize {
+	select {
+	case hbase := <-p.clients:
+		return hbase, nil
+	case <-time.After(time.Millisecond):
 		select {
 		case hbase := <-p.clients:
 			return hbase, nil
-		default:
+		case p.createSem <- true:
+			// No existing client, let's make a new one
 			hbase, err := func() (*HBaseClient, error) {
 				p.clientLock.Lock()
 				defer p.clientLock.Unlock()
 
-				if p.activeClients < p.poolSize {
-					var transport thrift.TTransport
-					transport, err := thrift.NewTSocket(p.hostPort)
-					if err != nil {
-						return nil, err
-					}
-
-					err = transport.Open()
-					if err != nil {
-						return nil, err
-					}
-
-					transport, err = p.transportFactory.GetTransport(transport)
-					if err != nil {
-						return nil, err
-					}
-
-					p.activeClients += 1
-					return &HBaseClient{
-						hbase:     hb.NewHbaseClientFactory(transport, p.protocolFactory),
-						transport: transport,
-					}, nil
-				} else {
-					return nil, nil
+				var transport thrift.TTransport
+				transport, err := thrift.NewTSocket(p.hostPort)
+				if err != nil {
+					return nil, err
 				}
+
+				err = transport.Open()
+				if err != nil {
+					return nil, err
+				}
+
+				transport, err = p.transportFactory.GetTransport(transport)
+				if err != nil {
+					return nil, err
+				}
+
+				return &HBaseClient{
+					hbase:     hb.NewHbaseClientFactory(transport, p.protocolFactory),
+					transport: transport,
+				}, nil
 			}()
-
 			if err != nil {
-				return nil, err
+				// On error, release our create hold
+				<-p.createSem
 			}
-
-			if hbase != nil {
-				return hbase, nil
-			}
+			return hbase, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
-	}
-
-	select {
-	case hbase := <-p.clients:
-		return hbase, nil
-	case <-ctx.Done():
-		return nil, ctx.Err()
 	}
 }
 
 func (p *Pool) Release(hbase *HBaseClient) {
-	p.clients <- hbase
+	select {
+	case p.clients <- hbase:
+	default:
+		// pool overflow
+		<-p.createSem
+		hbase.transport.Close()
+	}
 }
 
 func (p *Pool) Close(ctx context.Context) error {
-	for p.activeClients > 0 {
-		select {
-		case hbaseClient := <-p.clients:
-			hbaseClient.transport.Close()
-			p.activeClients -= 1
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+	close(p.clients)
+	for hbaseClient := range p.clients {
+		hbaseClient.transport.Close()
 	}
 	return nil
 }


### PR DESCRIPTION
Problem: idle client are throwing EOF errors on attempt to use it.
Caused by: server can close idle sockets by timeout.
Solution: implement logic for closing idle clients to avoid errors on pool requests